### PR TITLE
JIR-10601 - Fixed FCM Token related warning happening at iOS end.

### DIFF
--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -250,5 +250,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 + (void)deleteInstanceId:(void (^)(NSError *error))handler {
     //Replaced deleteIDWithHandler with deleteDataWithCompletion to delete FCM token.
     [[FIRMessaging messaging] deleteDataWithCompletion:handler];
+    //Added deleteWithCompletion method to delete FCM instance on logout. 
+    [[FIRInstallations installations] deleteWithCompletion:handler];
 }
 @end


### PR DESCRIPTION
Added  additional method deleteWithCompletion of FIRInstallations to delete FCM instance id which was not getting deleted before. 