### PR TITLE
DEV-19182: Fixed no notifications received on app after zoom recreates it

### DIFF
--- a/src/android/com/hrs/firebase/messaging/FCMPlugin.java
+++ b/src/android/com/hrs/firebase/messaging/FCMPlugin.java
@@ -52,6 +52,10 @@ public class FCMPlugin extends CordovaPlugin {
     @Override
     public void pluginInitialize() {
         super.pluginInitialize();
+        this.setupPlugin();
+    }
+
+    public void setupPlugin() {
         instance = this;
         Timber.d("==> FCMPlugin initialize");
         FirebaseMessaging.getInstance().subscribeToTopic("android");
@@ -61,8 +65,13 @@ public class FCMPlugin extends CordovaPlugin {
     @Override
     public void onDestroy() {
         Timber.i("onDestroy()");
-        instance = null;
-        initialPushPayload = null;
+        if (this == instance) {
+            Timber.d("onDestroy clearing static instance");
+            instance = null;
+            initialPushPayload = null;
+        } else {
+            Timber.d("onDestroy Not clearing static instance");
+        }
     }
 
     public boolean execute(
@@ -107,6 +116,9 @@ public class FCMPlugin extends CordovaPlugin {
                 case ACTION_INIT_DIFFERENT_ACCOUNT:
                     cordova.getThreadPool().execute(() -> {
                         try {
+                            if (instance == null) {
+                                this.setupPlugin();
+                            }
                             Context context = cordova.getActivity();
                             if (!FirebaseApp.getApps(context).isEmpty()) {
                                 FirebaseApp app = FirebaseApp.getInstance("[DEFAULT]");


### PR DESCRIPTION
When Zoom call ending causes the app to recreate, FCM plugin does get initialised but due to race conditions, at times, life cycle methods are not getting executed sequentially giving rise to situations in which we dont have an FCM instance initialized properly. With this fix, we make sure that onDestory wont nullify the singleton instance if it is not the current one. Also, in any rare use case if the instance is null, we initialize it on initDifferentAccount scenario when the app is initialized.