### PR TITLE
DEV-20855 : Fix for call modal appearing for old calls once CC2 leaves the call

### DIFF
--- a/src/android/com/hrs/firebase/messaging/FCMPlugin.java
+++ b/src/android/com/hrs/firebase/messaging/FCMPlugin.java
@@ -68,6 +68,10 @@ public class FCMPlugin extends CordovaPlugin {
         this.setupPlugin();
     }
 
+    public static FCMPlugin getInstance() {
+        return instance;
+    }
+
     public void setupPlugin() {
         instance = this;
         Timber.d("==> FCMPlugin initialize");

--- a/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
+++ b/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
@@ -109,9 +109,14 @@ public class FCMPluginActivity extends Activity {
         data.put("wasTapped", wasTapped);
         clearIncomingCall(intent);
         FCMPlugin.sendPushPayload(data);
-        FCMPlugin.setInitialPushPayload(data);
-    }
 
+        Timber.d("FCMPlugin.getInstance().cordova.getActivity() " + FCMPlugin.getInstance());
+        if (FCMPlugin.getInstance() == null) { // app isnt running yet
+            Timber.d("Set initialPushPayload when the app isnt running");
+            FCMPlugin.setInitialPushPayload(data);
+        }
+    }
+    
     private void clearIncomingCall(Intent intent) {
         MyRingtoneManager.getInstance().stopRingtone();
         int notificationId = intent.getIntExtra("notificationId", -1);


### PR DESCRIPTION
Set intialPushPayload only when app isnt running and not always as this leads to incorrect payload (which has already been attended) set in the intialPush object. 