### PR TITLE
Fixed DEV-21954 [KM PCMT] Voice/Video call banner does not launch the PCMT app or connect call when answered from the native KM home screen while the app is closed

### DIFF
--- a/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
+++ b/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
@@ -3,20 +3,12 @@ package com.hrs.firebase.messaging;
 import static org.apache.cordova.BuildHelper.getBuildConfigValue;
 
 import android.app.Activity;
-import android.app.Application;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
-import android.util.Log;
 import android.view.View;
-import android.view.WindowManager;
-
-
-import androidx.annotation.NonNull;
 
 import com.hrs.firebase.messaging.incomingcall.Constants;
 import com.hrs.firebase.messaging.incomingcall.IncomingCallService;
@@ -31,8 +23,6 @@ import timber.log.Timber;
 
 public class FCMPluginActivity extends Activity {
 
-    private final CustomActivityLifecycleCallbacks lifecycleCallbacks = new CustomActivityLifecycleCallbacks();
-
     /*
      * this activity will be started if the user touches a notification that we own.
      * We send it's data off to the push plugin for processing.
@@ -41,7 +31,6 @@ public class FCMPluginActivity extends Activity {
      */
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        getApplication().registerActivityLifecycleCallbacks(lifecycleCallbacks);
         super.onCreate(savedInstanceState);
         Timber.d("==> FCMPluginActivity onCreate");
         Intent intent = getIntent();
@@ -150,10 +139,6 @@ public class FCMPluginActivity extends Activity {
         final NotificationManager notificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager.cancelAll();
 
-//
-//            View decorView = getWindow().getDecorView();
-//            decorView.postInvalidate();
-
     }
 
     @Override
@@ -168,57 +153,6 @@ public class FCMPluginActivity extends Activity {
         Timber.d("==> FCMPluginActivity onStop");
         View decorView = getWindow().getDecorView();
         decorView.postInvalidate();
-    }
-
-    public class CustomActivityLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
-
-        @Override
-        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-            Timber.i("onCreate(): %s", activity.getClass().getSimpleName());
-        }
-
-        @Override
-        public void onActivityStarted(Activity activity) {
-            Timber.i("onStart(): %s", activity.getClass().getSimpleName());
-        }
-
-        @Override
-        public void onActivityResumed(Activity activity) {
-            Timber.i("onResume(): %s", activity.getClass().getSimpleName());
-        }
-
-        @Override
-        public void onActivityPaused(Activity activity) {
-            Timber.i("onPause(): %s", activity.getClass().getSimpleName());
-            Log.d("AB", "********* FCMPLUGIN ACTIVITY --->> ON PAUSE called -->> Relayouting");
-            if (activity.getClass().getSimpleName().contains("MainActivity")) {
-//                Log.d("AB", "--->> ON PAUSE called -->> Relayouting");
-//                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-//                getWindow().getDecorView().postInvalidate();
-//                getWindow().getDecorView().requestLayout();;
-                new Handler(Looper.getMainLooper()).postDelayed(() -> { // TODO check for UI thread
-                // Step 3: Finish current activity
-                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-                getWindow().getDecorView().postInvalidate();
-                getWindow().getDecorView().requestLayout();
-            }, 1000);
-            }
-        }
-
-        @Override
-        public void onActivitySaveInstanceState(Activity activity, @NonNull Bundle outState) {
-            Timber.i("onSaveInstanceState(): %s", activity.getClass().getSimpleName());
-        }
-
-        @Override
-        public void onActivityStopped(Activity activity) {
-            Timber.i("onStop(): %s", activity.getClass().getSimpleName());
-        }
-
-        @Override
-        public void onActivityDestroyed(Activity activity) {
-            Timber.i("onDestroy(): %s", activity.getClass().getSimpleName());
-        }
     }
 
 }

--- a/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
+++ b/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+
 import android.view.View;
 
 import com.hrs.firebase.messaging.incomingcall.Constants;
@@ -22,7 +23,6 @@ import java.util.Objects;
 import timber.log.Timber;
 
 public class FCMPluginActivity extends Activity {
-
     /*
      * this activity will be started if the user touches a notification that we own.
      * We send it's data off to the push plugin for processing.
@@ -138,7 +138,6 @@ public class FCMPluginActivity extends Activity {
         Timber.d("==> FCMPluginActivity onResume");
         final NotificationManager notificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager.cancelAll();
-
     }
 
     @Override
@@ -151,8 +150,6 @@ public class FCMPluginActivity extends Activity {
     public void onStop() {
         super.onStop();
         Timber.d("==> FCMPluginActivity onStop");
-        View decorView = getWindow().getDecorView();
-        decorView.postInvalidate();
     }
 
 }

--- a/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
+++ b/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
@@ -3,12 +3,20 @@ package com.hrs.firebase.messaging;
 import static org.apache.cordova.BuildHelper.getBuildConfigValue;
 
 import android.app.Activity;
+import android.app.Application;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.view.View;
+import android.view.WindowManager;
 
+
+import androidx.annotation.NonNull;
 
 import com.hrs.firebase.messaging.incomingcall.Constants;
 import com.hrs.firebase.messaging.incomingcall.IncomingCallService;
@@ -22,6 +30,9 @@ import java.util.Objects;
 import timber.log.Timber;
 
 public class FCMPluginActivity extends Activity {
+
+    private final CustomActivityLifecycleCallbacks lifecycleCallbacks = new CustomActivityLifecycleCallbacks();
+
     /*
      * this activity will be started if the user touches a notification that we own.
      * We send it's data off to the push plugin for processing.
@@ -30,6 +41,7 @@ public class FCMPluginActivity extends Activity {
      */
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        getApplication().registerActivityLifecycleCallbacks(lifecycleCallbacks);
         super.onCreate(savedInstanceState);
         Timber.d("==> FCMPluginActivity onCreate");
         Intent intent = getIntent();
@@ -137,6 +149,11 @@ public class FCMPluginActivity extends Activity {
         Timber.d("==> FCMPluginActivity onResume");
         final NotificationManager notificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager.cancelAll();
+
+//
+//            View decorView = getWindow().getDecorView();
+//            decorView.postInvalidate();
+
     }
 
     @Override
@@ -149,6 +166,59 @@ public class FCMPluginActivity extends Activity {
     public void onStop() {
         super.onStop();
         Timber.d("==> FCMPluginActivity onStop");
+        View decorView = getWindow().getDecorView();
+        decorView.postInvalidate();
+    }
+
+    public class CustomActivityLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
+
+        @Override
+        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+            Timber.i("onCreate(): %s", activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivityStarted(Activity activity) {
+            Timber.i("onStart(): %s", activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivityResumed(Activity activity) {
+            Timber.i("onResume(): %s", activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivityPaused(Activity activity) {
+            Timber.i("onPause(): %s", activity.getClass().getSimpleName());
+            Log.d("AB", "********* FCMPLUGIN ACTIVITY --->> ON PAUSE called -->> Relayouting");
+            if (activity.getClass().getSimpleName().contains("MainActivity")) {
+//                Log.d("AB", "--->> ON PAUSE called -->> Relayouting");
+//                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+//                getWindow().getDecorView().postInvalidate();
+//                getWindow().getDecorView().requestLayout();;
+                new Handler(Looper.getMainLooper()).postDelayed(() -> { // TODO check for UI thread
+                // Step 3: Finish current activity
+                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+                getWindow().getDecorView().postInvalidate();
+                getWindow().getDecorView().requestLayout();
+            }, 1000);
+            }
+        }
+
+        @Override
+        public void onActivitySaveInstanceState(Activity activity, @NonNull Bundle outState) {
+            Timber.i("onSaveInstanceState(): %s", activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivityStopped(Activity activity) {
+            Timber.i("onStop(): %s", activity.getClass().getSimpleName());
+        }
+
+        @Override
+        public void onActivityDestroyed(Activity activity) {
+            Timber.i("onDestroy(): %s", activity.getClass().getSimpleName());
+        }
     }
 
 }

--- a/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
+++ b/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 
 
 import com.hrs.firebase.messaging.incomingcall.Constants;
+import com.hrs.firebase.messaging.incomingcall.IncomingCallService;
 
 import org.json.JSONException;
 
@@ -34,6 +35,9 @@ public class FCMPluginActivity extends Activity {
         Intent intent = getIntent();
         String action = intent.getAction();
         if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
+            Intent intent1 = new Intent(this, IncomingCallService.class);
+            stopService(intent1);
+
             this.openCall(intent, true);
         } else {
             this.sendPushPayload();

--- a/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
+++ b/src/android/com/hrs/firebase/messaging/FCMPluginActivity.java
@@ -35,8 +35,8 @@ public class FCMPluginActivity extends Activity {
         Intent intent = getIntent();
         String action = intent.getAction();
         if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
-            Intent intent1 = new Intent(this, IncomingCallService.class);
-            stopService(intent1);
+            Intent callServiceIntent = new Intent(this, IncomingCallService.class);
+            stopService(callServiceIntent);
 
             this.openCall(intent, true);
         } else {

--- a/src/android/com/hrs/firebase/messaging/MyFirebaseMessagingService.java
+++ b/src/android/com/hrs/firebase/messaging/MyFirebaseMessagingService.java
@@ -2,14 +2,21 @@ package com.hrs.firebase.messaging;
 
 import static org.apache.cordova.BuildHelper.getBuildConfigValue;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
+import com.hrs.firebase.messaging.incomingcall.Constants;
 import com.hrs.firebase.messaging.incomingcall.IncomingCall;
 
 import org.apache.cordova.CordovaWebView;

--- a/src/android/com/hrs/firebase/messaging/MyFirebaseMessagingService.java
+++ b/src/android/com/hrs/firebase/messaging/MyFirebaseMessagingService.java
@@ -2,21 +2,14 @@ package com.hrs.firebase.messaging;
 
 import static org.apache.cordova.BuildHelper.getBuildConfigValue;
 
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.os.Bundle;
 
 import androidx.annotation.NonNull;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
-import com.hrs.firebase.messaging.incomingcall.Constants;
 import com.hrs.firebase.messaging.incomingcall.IncomingCall;
 
 import org.apache.cordova.CordovaWebView;
@@ -155,160 +148,3 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         }
     }
 }
-//package com.hrs.firebase.messaging;
-//
-//import static org.apache.cordova.BuildHelper.getBuildConfigValue;
-//
-//import android.app.Activity;
-//import android.app.Application;
-//import android.content.pm.PackageManager;
-//import android.os.Build;
-//import android.os.Bundle;
-//import android.util.Log;
-//import android.view.View;
-//
-//import androidx.annotation.NonNull;
-//
-//import com.google.firebase.messaging.FirebaseMessaging;
-//import com.google.firebase.messaging.FirebaseMessagingService;
-//import com.google.firebase.messaging.RemoteMessage;
-//import com.hrs.firebase.messaging.incomingcall.IncomingCall;
-//
-//import org.apache.cordova.CordovaWebView;
-//import org.json.JSONException;
-//import org.json.JSONObject;
-//
-//
-//import java.util.HashMap;
-//import java.util.Objects;
-//
-//import timber.log.Timber;
-//
-//public class MyFirebaseMessagingService extends FirebaseMessagingService {
-//
-//    public static CordovaWebView webView = null;
-//
-//    @Override
-//    public void onNewToken(@NonNull String token) {
-//        super.onNewToken(token);
-//        Timber.d("New token: %s", token);
-//        FCMPlugin.sendTokenRefresh(token);
-//    }
-//
-//    /**
-//     * Called when message is received.
-//     *
-//     * @param remoteMessage Object representing the message received from Firebase Cloud Messaging.
-//     */
-//    // [START receive_message]
-//    @Override
-//    public void onMessageReceived(RemoteMessage remoteMessage) {
-////        // TODO(developer): Handle FCM messages here.
-////        // If the application is in the foreground handle both data and notification messages here.
-////        // Also if you intend on generating your own notifications as a result of a received FCM
-////        // message, here is where that should be initiated. See sendNotification method below.
-//        Timber.d("==> MyFirebaseMessagingService onMessageReceived");
-////
-//        if(remoteMessage.getNotification() != null){
-//            Timber.d("	Notification Title: %s", remoteMessage.getNotification().getTitle());
-//            Timber.d("	Notification Message: %s", remoteMessage.getNotification().getBody());
-//        }
-//
-//        HashMap<String, Object> data = new HashMap<String, Object>();
-//        data.put("wasTapped", false);
-//
-//        if(remoteMessage.getNotification() != null){
-//            data.put("title", remoteMessage.getNotification().getTitle());
-//            data.put("body", remoteMessage.getNotification().getBody());
-//        }
-//
-//        for (String key : remoteMessage.getData().keySet()) {
-//            Object value = remoteMessage.getData().get(key);
-//            Timber.d("\tKey: " + key + " Value: " + value);
-//            data.put(key, value);
-//        }
-//
-//
-//        Boolean isKnoxManage = (Boolean) getBuildConfigValue(getApplicationContext(), "KNOXMANAGE");
-//        if (FCMPlugin.appInForeground || Build.VERSION.SDK_INT <= Build.VERSION_CODES.S || Boolean.FALSE.equals(isKnoxManage)) {
-//            FCMPlugin.sendPushPayload(data);
-//        } else {
-//            JSONObject jsonData = null;
-//            try {
-//                jsonData = new JSONObject((String) Objects.requireNonNull(data.get("jsonData")));
-//            } catch (JSONException e) {
-//                Timber.e(e, "Error decoding jsonData from push notification");
-//            }
-//
-//            if (jsonData != null && jsonData.optString("action").equals("incoming_call")) {
-//                try {
-//                    handleIncomingCall(jsonData, Utils.createNotificationId(jsonData.getString("id")));
-//                } catch (JSONException e) {
-//                    Timber.e("Error handling incoming call: %s", e.getMessage());
-//                }
-//            } else if (jsonData != null && jsonData.optString("action").equals("call_left")) {
-//                IncomingCall.callLeft(this);
-//                FCMPlugin.sendPushPayload(data);
-//            } else if (jsonData != null && !jsonData.optString("title").isEmpty()) {
-//                handleGenericNotification(jsonData);
-//                try {
-//                    SharedPreferencesManager.getInstance(this).storeNotification(jsonData.getString("id"), jsonData);
-//                } catch (JSONException e) {
-//                    Timber.e("Error getting storing notification in shared preferences: %s", e.getMessage());
-//                }
-//
-//                if (jsonData.optString("status").equals("deactivate")) {
-//                    Timber.d("Incoming deactivate patient notification. Deleting token.");
-//                    try {
-//                        FirebaseMessaging.getInstance().deleteToken();
-//                    } catch (Exception e) {
-//                        Timber.e("Patient deactivated. Error deleting Firebase instance: %s", e.getMessage());
-//                    }
-//                }
-//            } else {
-//                FCMPlugin.sendPushPayload(data);
-//            }
-//        }
-//
-//        Timber.d("	Notification Data: %s", data.toString());
-//    }
-//
-//    private void handleGenericNotification(JSONObject jsonData) {
-//        try {
-//            new GenericNotification().show(this, jsonData);
-//        } catch (JSONException e) {
-//            Timber.e("Failed to generate generic notification  %s", e.getMessage());
-//        } catch (PackageManager.NameNotFoundException e) {
-//            Timber.e("Failed to find package name/icon for generic notification  %s", e.getMessage());
-//        }
-//    }
-//
-//
-//    private void handleIncomingCall(JSONObject jsonData, int notificationId) {
-//        String name = "";
-//        String title = "";
-//        if (jsonData.optString("type").equals("video") || jsonData.optString("type").equals("video-zoom")) {
-//            JSONObject caller = jsonData.optJSONObject("caller");
-//            if (caller != null) {
-//                name = caller.optString("name");
-//            }
-//
-//            title = "Incoming Video Call";
-//        } else if (jsonData.optString("type").equals("voice") || jsonData.optString("type").equals("voicecall")) {
-//            JSONObject callData = jsonData.optJSONObject("data");
-//            if (callData != null) {
-//                name = callData.optString("from");
-//            }
-//            title = "Incoming Voice Call";
-//        }
-//
-//        try {
-//            IncomingCall.showNotification(this, name, title, Utils.jsonToBundle(jsonData));
-//        } catch (JSONException e) {
-//            Timber.e("Failed to show incoming call notification%s", e.getMessage());
-//        }
-//    }
-//
-//
-//
-//}

--- a/src/android/com/hrs/firebase/messaging/MyFirebaseMessagingService.java
+++ b/src/android/com/hrs/firebase/messaging/MyFirebaseMessagingService.java
@@ -2,19 +2,21 @@ package com.hrs.firebase.messaging;
 
 import static org.apache.cordova.BuildHelper.getBuildConfigValue;
 
-import android.app.Activity;
-import android.app.Application;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
-import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
+import com.hrs.firebase.messaging.incomingcall.Constants;
 import com.hrs.firebase.messaging.incomingcall.IncomingCall;
 
 import org.apache.cordova.CordovaWebView;
@@ -37,6 +39,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         Timber.d("New token: %s", token);
         FCMPlugin.sendTokenRefresh(token);
     }
+
 
     /**
      * Called when message is received.
@@ -151,7 +154,161 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
             Timber.e("Failed to show incoming call notification%s", e.getMessage());
         }
     }
-
-
-
 }
+//package com.hrs.firebase.messaging;
+//
+//import static org.apache.cordova.BuildHelper.getBuildConfigValue;
+//
+//import android.app.Activity;
+//import android.app.Application;
+//import android.content.pm.PackageManager;
+//import android.os.Build;
+//import android.os.Bundle;
+//import android.util.Log;
+//import android.view.View;
+//
+//import androidx.annotation.NonNull;
+//
+//import com.google.firebase.messaging.FirebaseMessaging;
+//import com.google.firebase.messaging.FirebaseMessagingService;
+//import com.google.firebase.messaging.RemoteMessage;
+//import com.hrs.firebase.messaging.incomingcall.IncomingCall;
+//
+//import org.apache.cordova.CordovaWebView;
+//import org.json.JSONException;
+//import org.json.JSONObject;
+//
+//
+//import java.util.HashMap;
+//import java.util.Objects;
+//
+//import timber.log.Timber;
+//
+//public class MyFirebaseMessagingService extends FirebaseMessagingService {
+//
+//    public static CordovaWebView webView = null;
+//
+//    @Override
+//    public void onNewToken(@NonNull String token) {
+//        super.onNewToken(token);
+//        Timber.d("New token: %s", token);
+//        FCMPlugin.sendTokenRefresh(token);
+//    }
+//
+//    /**
+//     * Called when message is received.
+//     *
+//     * @param remoteMessage Object representing the message received from Firebase Cloud Messaging.
+//     */
+//    // [START receive_message]
+//    @Override
+//    public void onMessageReceived(RemoteMessage remoteMessage) {
+////        // TODO(developer): Handle FCM messages here.
+////        // If the application is in the foreground handle both data and notification messages here.
+////        // Also if you intend on generating your own notifications as a result of a received FCM
+////        // message, here is where that should be initiated. See sendNotification method below.
+//        Timber.d("==> MyFirebaseMessagingService onMessageReceived");
+////
+//        if(remoteMessage.getNotification() != null){
+//            Timber.d("	Notification Title: %s", remoteMessage.getNotification().getTitle());
+//            Timber.d("	Notification Message: %s", remoteMessage.getNotification().getBody());
+//        }
+//
+//        HashMap<String, Object> data = new HashMap<String, Object>();
+//        data.put("wasTapped", false);
+//
+//        if(remoteMessage.getNotification() != null){
+//            data.put("title", remoteMessage.getNotification().getTitle());
+//            data.put("body", remoteMessage.getNotification().getBody());
+//        }
+//
+//        for (String key : remoteMessage.getData().keySet()) {
+//            Object value = remoteMessage.getData().get(key);
+//            Timber.d("\tKey: " + key + " Value: " + value);
+//            data.put(key, value);
+//        }
+//
+//
+//        Boolean isKnoxManage = (Boolean) getBuildConfigValue(getApplicationContext(), "KNOXMANAGE");
+//        if (FCMPlugin.appInForeground || Build.VERSION.SDK_INT <= Build.VERSION_CODES.S || Boolean.FALSE.equals(isKnoxManage)) {
+//            FCMPlugin.sendPushPayload(data);
+//        } else {
+//            JSONObject jsonData = null;
+//            try {
+//                jsonData = new JSONObject((String) Objects.requireNonNull(data.get("jsonData")));
+//            } catch (JSONException e) {
+//                Timber.e(e, "Error decoding jsonData from push notification");
+//            }
+//
+//            if (jsonData != null && jsonData.optString("action").equals("incoming_call")) {
+//                try {
+//                    handleIncomingCall(jsonData, Utils.createNotificationId(jsonData.getString("id")));
+//                } catch (JSONException e) {
+//                    Timber.e("Error handling incoming call: %s", e.getMessage());
+//                }
+//            } else if (jsonData != null && jsonData.optString("action").equals("call_left")) {
+//                IncomingCall.callLeft(this);
+//                FCMPlugin.sendPushPayload(data);
+//            } else if (jsonData != null && !jsonData.optString("title").isEmpty()) {
+//                handleGenericNotification(jsonData);
+//                try {
+//                    SharedPreferencesManager.getInstance(this).storeNotification(jsonData.getString("id"), jsonData);
+//                } catch (JSONException e) {
+//                    Timber.e("Error getting storing notification in shared preferences: %s", e.getMessage());
+//                }
+//
+//                if (jsonData.optString("status").equals("deactivate")) {
+//                    Timber.d("Incoming deactivate patient notification. Deleting token.");
+//                    try {
+//                        FirebaseMessaging.getInstance().deleteToken();
+//                    } catch (Exception e) {
+//                        Timber.e("Patient deactivated. Error deleting Firebase instance: %s", e.getMessage());
+//                    }
+//                }
+//            } else {
+//                FCMPlugin.sendPushPayload(data);
+//            }
+//        }
+//
+//        Timber.d("	Notification Data: %s", data.toString());
+//    }
+//
+//    private void handleGenericNotification(JSONObject jsonData) {
+//        try {
+//            new GenericNotification().show(this, jsonData);
+//        } catch (JSONException e) {
+//            Timber.e("Failed to generate generic notification  %s", e.getMessage());
+//        } catch (PackageManager.NameNotFoundException e) {
+//            Timber.e("Failed to find package name/icon for generic notification  %s", e.getMessage());
+//        }
+//    }
+//
+//
+//    private void handleIncomingCall(JSONObject jsonData, int notificationId) {
+//        String name = "";
+//        String title = "";
+//        if (jsonData.optString("type").equals("video") || jsonData.optString("type").equals("video-zoom")) {
+//            JSONObject caller = jsonData.optJSONObject("caller");
+//            if (caller != null) {
+//                name = caller.optString("name");
+//            }
+//
+//            title = "Incoming Video Call";
+//        } else if (jsonData.optString("type").equals("voice") || jsonData.optString("type").equals("voicecall")) {
+//            JSONObject callData = jsonData.optJSONObject("data");
+//            if (callData != null) {
+//                name = callData.optString("from");
+//            }
+//            title = "Incoming Voice Call";
+//        }
+//
+//        try {
+//            IncomingCall.showNotification(this, name, title, Utils.jsonToBundle(jsonData));
+//        } catch (JSONException e) {
+//            Timber.e("Failed to show incoming call notification%s", e.getMessage());
+//        }
+//    }
+//
+//
+//
+//}

--- a/src/android/com/hrs/firebase/messaging/MyFirebaseMessagingService.java
+++ b/src/android/com/hrs/firebase/messaging/MyFirebaseMessagingService.java
@@ -2,21 +2,19 @@ package com.hrs.firebase.messaging;
 
 import static org.apache.cordova.BuildHelper.getBuildConfigValue;
 
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
+import android.app.Activity;
+import android.app.Application;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
 
 import androidx.annotation.NonNull;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
-import com.hrs.firebase.messaging.incomingcall.Constants;
 import com.hrs.firebase.messaging.incomingcall.IncomingCall;
 
 import org.apache.cordova.CordovaWebView;
@@ -39,7 +37,6 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         Timber.d("New token: %s", token);
         FCMPlugin.sendTokenRefresh(token);
     }
-
 
     /**
      * Called when message is received.
@@ -154,4 +151,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
             Timber.e("Failed to show incoming call notification%s", e.getMessage());
         }
     }
+
+
+
 }

--- a/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
+++ b/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
@@ -49,7 +49,6 @@ public class IncomingCallActivity extends AppCompatActivity {
         hideSystemUI();
 
         setContentView(getResources().getIdentifier("activity_incoming_call", "layout", getPackageName()));
-        Log.d("AB", "----->> ON CREATE hiding system UI");
 
         String callerName = getIntent().getStringExtra(Constants.EXTRA_CALLER_NAME);
         String callTitle = getIntent().getStringExtra(Constants.EXTRA_CALL_TITLE);
@@ -92,9 +91,6 @@ public class IncomingCallActivity extends AppCompatActivity {
             callActionReceiver, new IntentFilter(Constants.ACTION_CALL_LEFT));
 
     }
-
-
-
 
     @Override
     protected void onDestroy() {

--- a/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
+++ b/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
@@ -1,116 +1,116 @@
-package com.hrs.firebase.messaging.incomingcall;
+    package com.hrs.firebase.messaging.incomingcall;
 
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.os.Bundle;
-import android.view.View;
-import android.view.WindowManager;
-import android.widget.TextView;
+    import android.content.BroadcastReceiver;
+    import android.content.Context;
+    import android.content.Intent;
+    import android.content.IntentFilter;
+    import android.os.Bundle;
+    import android.view.View;
+    import android.view.WindowManager;
+    import android.widget.TextView;
 
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+    import androidx.appcompat.app.AppCompatActivity;
+    import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
-import com.hrs.firebase.messaging.FCMPluginActivity;
+    import com.hrs.firebase.messaging.FCMPluginActivity;
 
-public class IncomingCallActivity extends AppCompatActivity {
-    private Bundle extras;
-    private String action;
+    public class IncomingCallActivity extends AppCompatActivity {
+        private Bundle extras;
+        private String action;
 
-    private final BroadcastReceiver callActionReceiver = new BroadcastReceiver() {
+        private final BroadcastReceiver callActionReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (Constants.ACTION_CALL_LEFT.equals(intent.getAction()) ||
+                    Constants.ACTION_CALL_TIMEOUT.equals(intent.getAction())
+                ) {
+                    restoreSystemUi();
+                    finish();
+                }
+            }
+        };
+
+
         @Override
-        public void onReceive(Context context, Intent intent) {
-            if (Constants.ACTION_CALL_LEFT.equals(intent.getAction()) ||
-                Constants.ACTION_CALL_TIMEOUT.equals(intent.getAction())
-            ) {
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            hideSystemUI();
+
+            setContentView(getResources().getIdentifier("activity_incoming_call", "layout", getPackageName()));
+
+            String callerName = getIntent().getStringExtra(Constants.EXTRA_CALLER_NAME);
+            String callTitle = getIntent().getStringExtra(Constants.EXTRA_CALL_TITLE);
+            extras = getIntent().getExtras();
+
+            int callerNameId = getResources().getIdentifier("caller_name", "id", getPackageName());
+            TextView callerNameView = findViewById(callerNameId);
+
+            int callTitleId = getResources().getIdentifier("call_title", "id", getPackageName());
+            TextView callTitleView = findViewById(callTitleId);
+
+            callerNameView.setText(callerName);
+            callTitleView.setText(callTitle);
+
+            // Wake up the device and show the activity
+            getWindow().addFlags(
+                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
+                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+            );
+
+            int answerButtonId = getResources().getIdentifier("answer_button", "id", getPackageName());
+            findViewById(answerButtonId).setOnClickListener(v -> {
+                action = Constants.ACTION_ANSWER_CALL;
                 restoreSystemUi();
                 finish();
+            });
+
+            int declineButtonId = getResources().getIdentifier("decline_button", "id", getPackageName());
+            findViewById(declineButtonId).setOnClickListener(v -> {
+                Intent intent = new Intent(this, IncomingCallService.class);
+                intent.setAction(Constants.ACTION_DECLINE_CALL);
+                intent.putExtras(extras);
+                startService(intent);
+                restoreSystemUi();
+                finish();
+            });
+
+            LocalBroadcastManager.getInstance(this).registerReceiver(
+                callActionReceiver, new IntentFilter(Constants.ACTION_CALL_LEFT));
+
+        }
+
+        @Override
+        protected void onDestroy() {
+            super.onDestroy();
+            LocalBroadcastManager.getInstance(this).unregisterReceiver(callActionReceiver);
+            if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
+                Intent incomingCallIntent = getIntent();
+                Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
+                int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
+                Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
+                intent.setAction(Constants.ACTION_ANSWER_CALL);
+                intent.putExtra("data", data);
+                intent.putExtra("notificationId", notificationId);
+                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+                startActivity(intent);
+                action = null;
             }
         }
-    };
 
+        private void hideSystemUI() {
+            getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_IMMERSIVE
+                    | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    | View.SYSTEM_UI_FLAG_FULLSCREEN
+            );
+        }
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        hideSystemUI();
-
-        setContentView(getResources().getIdentifier("activity_incoming_call", "layout", getPackageName()));
-
-        String callerName = getIntent().getStringExtra(Constants.EXTRA_CALLER_NAME);
-        String callTitle = getIntent().getStringExtra(Constants.EXTRA_CALL_TITLE);
-        extras = getIntent().getExtras();
-
-        int callerNameId = getResources().getIdentifier("caller_name", "id", getPackageName());
-        TextView callerNameView = findViewById(callerNameId);
-
-        int callTitleId = getResources().getIdentifier("call_title", "id", getPackageName());
-        TextView callTitleView = findViewById(callTitleId);
-
-        callerNameView.setText(callerName);
-        callTitleView.setText(callTitle);
-
-        // Wake up the device and show the activity
-        getWindow().addFlags(
-            WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
-                WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
-                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-        );
-
-        int answerButtonId = getResources().getIdentifier("answer_button", "id", getPackageName());
-        findViewById(answerButtonId).setOnClickListener(v -> {
-            action = Constants.ACTION_ANSWER_CALL;
-            restoreSystemUi();
-            finish();
-        });
-
-        int declineButtonId = getResources().getIdentifier("decline_button", "id", getPackageName());
-        findViewById(declineButtonId).setOnClickListener(v -> {
-            Intent intent = new Intent(this, IncomingCallService.class);
-            intent.setAction(Constants.ACTION_DECLINE_CALL);
-            intent.putExtras(extras);
-            startService(intent);
-            restoreSystemUi();
-            finish();
-        });
-
-        LocalBroadcastManager.getInstance(this).registerReceiver(
-            callActionReceiver, new IntentFilter(Constants.ACTION_CALL_LEFT));
-
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(callActionReceiver);
-        if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
-            Intent incomingCallIntent = getIntent();
-            Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
-            int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
-            Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
-            intent.setAction(Constants.ACTION_ANSWER_CALL);
-            intent.putExtra("data", data);
-            intent.putExtra("notificationId", notificationId);
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-            startActivity(intent);
-            action = null;
+        private void restoreSystemUi() {
+            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
         }
     }
-
-    private void hideSystemUI() {
-        getWindow().getDecorView().setSystemUiVisibility(
-            View.SYSTEM_UI_FLAG_IMMERSIVE
-                | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_FULLSCREEN
-        );
-    }
-
-    private void restoreSystemUi() {
-        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-    }
-}

--- a/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
+++ b/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
@@ -75,19 +75,7 @@ public class IncomingCallActivity extends AppCompatActivity {
         findViewById(answerButtonId).setOnClickListener(v -> {
             action = Constants.ACTION_ANSWER_CALL;
             restoreSystemUi();
-//            new Handler(Looper.getMainLooper()).postDelayed(() -> {
-//                Intent incomingCallIntent = getIntent();
-//                Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
-//                int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
-//                Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
-//                intent.setAction(Constants.ACTION_ANSWER_CALL);
-//                intent.putExtra("data", data);
-//                intent.putExtra("notificationId", notificationId);
-//                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-//                startActivity(intent);
-//                finish();
-//                 }, 300);
-
+            finish();
         });
 
         int declineButtonId = getResources().getIdentifier("decline_button", "id", getPackageName());
@@ -103,42 +91,6 @@ public class IncomingCallActivity extends AppCompatActivity {
         LocalBroadcastManager.getInstance(this).registerReceiver(
             callActionReceiver, new IntentFilter(Constants.ACTION_CALL_LEFT));
 
-                    getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
-                @Override
-                public void onSystemUiVisibilityChange(int visibility) {
-                    Log.d("AB", "---->>> On System UI Visibility Change " + visibility);
-                    if(visibility == 0) {
-                        if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
-                            // Step 2: Give system a short delay to redraw nav/status bars
-                            new Handler(Looper.getMainLooper()).postDelayed(() -> {
-                            Log.d("AB", "---->>> On System UI Visibility Change answer call action");
-                            //restoreSystemUi();
-                            Intent incomingCallIntent = getIntent();
-                            Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
-                            int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
-                            Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
-                            intent.setAction(Constants.ACTION_ANSWER_CALL);
-                            intent.putExtra("data", data);
-                            intent.putExtra("notificationId", notificationId);
-                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-
-                            startActivity(intent);
-
-                            // Step 2: Give system a short delay to redraw nav/status bars
-                           // new Handler(Looper.getMainLooper()).postDelayed(() -> {
-                                // Step 3: Finish current activity
-                                finish();
-                                action = null;
-//                                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
-//
-//                                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-                            }, 300);
-                           // finish(); // TODO thode delay se
-                        }
-                    }
-                }
-            });
-
     }
 
 
@@ -148,6 +100,18 @@ public class IncomingCallActivity extends AppCompatActivity {
     protected void onDestroy() {
         super.onDestroy();
         LocalBroadcastManager.getInstance(this).unregisterReceiver(callActionReceiver);
+        if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
+            Intent incomingCallIntent = getIntent();
+            Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
+            int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
+            Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
+            intent.setAction(Constants.ACTION_ANSWER_CALL);
+            intent.putExtra("data", data);
+            intent.putExtra("notificationId", notificationId);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            startActivity(intent);
+            action = null;
+        }
     }
 
     private void hideSystemUI() {
@@ -164,298 +128,5 @@ public class IncomingCallActivity extends AppCompatActivity {
     private void restoreSystemUi() {
         getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        getWindow().getDecorView().postInvalidate();
-        // getWindow().getDecorView().requestLayout();
     }
 }
-
-
-//    package com.hrs.firebase.messaging.incomingcall;
-//
-//    import android.app.ActivityManager;
-//    import android.app.PendingIntent;
-//    import android.content.BroadcastReceiver;
-//    import android.content.Context;
-//    import android.content.Intent;
-//    import android.content.IntentFilter;
-//    import android.os.Build;
-//    import android.os.Bundle;
-//    import android.os.Handler;
-//    import android.os.Looper;
-//    import android.util.Log;
-//    import android.view.KeyEvent;
-//    import android.view.View;
-//    import android.view.WindowInsets;
-//    import android.view.WindowInsetsController;
-//    import android.view.WindowManager;
-//    import android.widget.TextView;
-//
-//    import androidx.appcompat.app.AppCompatActivity;
-//    import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-//
-//    import com.hrs.firebase.messaging.FCMPluginActivity;
-//    import com.samsung.android.knox.EnterpriseDeviceManager;
-//    import com.samsung.android.knox.EnterpriseKnoxManager;
-//    import com.samsung.android.knox.kiosk.KioskMode;
-//
-//    public class IncomingCallActivity extends AppCompatActivity {
-//        private Bundle extras;
-//        private Intent intent;
-//        private String action;
-//
-//        private final BroadcastReceiver callActionReceiver = new BroadcastReceiver() {
-//            @Override
-//            public void onReceive(Context context, Intent intent) {
-//                if (Constants.ACTION_CALL_LEFT.equals(intent.getAction()) ||
-//                    Constants.ACTION_CALL_TIMEOUT.equals(intent.getAction())
-//                ) {
-//                    restoreSystemUi();
-//                    finish();
-//                }
-//            }
-//        };
-//
-//
-//        @Override
-//        protected void onCreate(Bundle savedInstanceState) {
-//            super.onCreate(savedInstanceState);
-//            hideSystemUI();
-////            EnterpriseDeviceManager ekm = EnterpriseDeviceManager.getInstance(this);
-////            KioskMode kiosk = ekm.getKioskMode();
-////            // kiosk.allowTaskManager(false);
-////            kiosk.hideNavigationBar(true);
-////            kiosk.hideStatusBar(true);
-////            // startLockTask();
-//
-//            setContentView(getResources().getIdentifier("activity_incoming_call", "layout", getPackageName()));
-//            Log.d("AB", "----->> ON CREATE hiding system UI");
-//
-//            String callerName = getIntent().getStringExtra(Constants.EXTRA_CALLER_NAME);
-//            String callTitle = getIntent().getStringExtra(Constants.EXTRA_CALL_TITLE);
-//            // intent = getIntent();
-//            extras = getIntent().getExtras();
-//
-//            int callerNameId = getResources().getIdentifier("caller_name", "id", getPackageName());
-//            TextView callerNameView = findViewById(callerNameId);
-//
-//            int callTitleId = getResources().getIdentifier("call_title", "id", getPackageName());
-//            TextView callTitleView = findViewById(callTitleId);
-//
-//            callerNameView.setText(callerName);
-//            callTitleView.setText(callTitle);
-//
-//            // Wake up the device and show the activity
-//            getWindow().addFlags(
-//                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
-//                            WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
-//                            WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-//            );
-//
-//            getWindow().setFlags(
-//                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
-//                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
-//            );
-//
-//            int answerButtonId = getResources().getIdentifier("answer_button", "id", getPackageName());
-//            findViewById(answerButtonId).setOnClickListener(v -> {
-//                  action = Constants.ACTION_ANSWER_CALL;
-//                  restoreSystemUi();
-//
-////                // Step 2: Give system a short delay to redraw nav/status bars
-////                new Handler(Looper.getMainLooper()).postDelayed(() -> {
-////                    // Step 3: Finish current activity
-////                    finish();
-////
-////                    // Step 4: Launch next activity
-////                    Intent incomingCallIntent = getIntent();
-////                Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
-////                int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
-////                Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
-////                intent.setAction(Constants.ACTION_ANSWER_CALL);
-////                intent.putExtra("data", data);
-////                intent.putExtra("notificationId", notificationId);
-////                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-////                startActivity(intent);
-////
-////                }, 300);
-////                  finish();
-//                //restoreSystemUi();
-////                Intent incomingCallIntent = getIntent();
-////                Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
-////                int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
-////                Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
-////                intent.setAction(Constants.ACTION_ANSWER_CALL);
-////                intent.putExtra("data", data);
-////                intent.putExtra("notificationId", notificationId);
-////                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-////                // restoreSystemUi();
-////                startActivity(intent);
-////                // restoreSystemUi();
-////                finish();
-//            });
-//
-//            int declineButtonId = getResources().getIdentifier("decline_button", "id", getPackageName());
-//            findViewById(declineButtonId).setOnClickListener(v -> {
-//                Intent intent = new Intent(this, IncomingCallService.class);
-//                intent.setAction(Constants.ACTION_DECLINE_CALL);
-//                intent.putExtras(extras);
-//                startService(intent);
-//                //restoreSystemUi();
-//                finish();
-//            });
-//
-//            LocalBroadcastManager.getInstance(this).registerReceiver(
-//                callActionReceiver, new IntentFilter(Constants.ACTION_CALL_LEFT));
-//
-//
-////            /**
-////             * Still issue occurs
-////             */
-//            getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
-//                @Override
-//                public void onSystemUiVisibilityChange(int visibility) {
-//                    Log.d("AB", "---->>> On System UI Visibility Change " + visibility);
-//                    if(visibility == 0) {
-//                        if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
-//                            // Step 2: Give system a short delay to redraw nav/status bars
-//                            new Handler(Looper.getMainLooper()).postDelayed(() -> {
-//                            Log.d("AB", "---->>> On System UI Visibility Change answer call action");
-//                            //restoreSystemUi();
-//                            Intent incomingCallIntent = getIntent();
-//                            Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
-//                            int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
-//                            Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
-//                            intent.setAction(Constants.ACTION_ANSWER_CALL);
-//                            intent.putExtra("data", data);
-//                            intent.putExtra("notificationId", notificationId);
-//                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-//
-//                            startActivity(intent);
-//
-//                            // Step 2: Give system a short delay to redraw nav/status bars
-//                           // new Handler(Looper.getMainLooper()).postDelayed(() -> {
-//                                // Step 3: Finish current activity
-//                                finish();
-//                                action = null;
-////                                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
-////
-////                                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-//                            }, 300);
-//                           // finish(); // TODO thode delay se
-//                        }
-//                    }
-//                }
-//            });
-//        }
-//
-//        @Override
-//        public void onBackPressed() {
-//           // super.onBackPressed();
-//        }
-//
-//        @Override
-//        public boolean dispatchKeyEvent(KeyEvent event) {
-//            int keyCode = event.getKeyCode();
-//            if (keyCode == KeyEvent.KEYCODE_HOME || keyCode == KeyEvent.KEYCODE_APP_SWITCH) {
-//                return true; // Block home & app switch keys
-//            }
-//            return super.dispatchKeyEvent(event);
-//        }
-//
-////        @Override
-////        protected void onResume() {
-////            super.onResume();
-////            startLockTask();
-////        }
-//
-//        @Override
-//        protected void onDestroy() {
-//            super.onDestroy();
-//            LocalBroadcastManager.getInstance(this).unregisterReceiver(callActionReceiver);
-////            if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
-//////                Intent intent = new Intent(this, IncomingCallService.class);
-//////                intent.setAction(Constants.ACTION_ANSWER_CALL);
-//////                intent.putExtras(extras);
-//////                startService(intent);
-////                Intent incomingCallIntent = getIntent();
-////                Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
-////                int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
-////                Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
-////                intent.setAction(Constants.ACTION_ANSWER_CALL);
-////                intent.putExtra("data", data);
-////                intent.putExtra("notificationId", notificationId);
-////                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-////                startActivity(intent);
-////            }
-//        }
-//
-//
-////        @Override
-////        protected void onStop() {
-////            super.onStop();
-////            Log.d("AB", "----->> ON STOP restoring system UI");
-////            restoreSystemUi();
-////        }
-//
-//        private void hideSystemUI() {
-//
-//            getWindow().getDecorView().setSystemUiVisibility(
-//                View.SYSTEM_UI_FLAG_IMMERSIVE
-//                    | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-//                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-//                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-//                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-//                    | View.SYSTEM_UI_FLAG_FULLSCREEN
-//            );
-////            getWindow().getDecorView().setSystemUiVisibility(
-////                     View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-////                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-////                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-////                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-////                    | View.SYSTEM_UI_FLAG_FULLSCREEN
-////            );
-//        }
-////
-//        private void restoreSystemUi() {
-//
-////            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-////                WindowInsetsController controller = getWindow().getInsetsController();
-////                if (controller != null) {
-////                    controller.show(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
-////                    controller.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_DEFAULT);
-////                }
-////            } else {
-//
-//            //NEHAL
-//            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-////            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
-////            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-//            //}
-//            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-//            getWindow().getDecorView().postInvalidate();
-//            //getWindow().getDecorView().invalidate();
-//            getWindow().getDecorView().requestLayout();;
-//
-//
-////            View decorView = getWindow().getDecorView();
-////            decorView.setSystemUiVisibility(
-////                View.SYSTEM_UI_FLAG_VISIBLE | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-////            );
-////            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-//            //getWindow().addFlags(
-//            //                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
-//            //                            WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
-//            //                            WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-//            //            );
-////            View decorView = getWindow().getDecorView();
-////            decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-////            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-////            getWindow().clearFlags(
-////                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
-////                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
-////                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-////            );
-//
-//        }
-//    }
-//

--- a/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
+++ b/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
@@ -1,108 +1,461 @@
-    package com.hrs.firebase.messaging.incomingcall;
+package com.hrs.firebase.messaging.incomingcall;
 
-    import android.content.BroadcastReceiver;
-    import android.content.Context;
-    import android.content.Intent;
-    import android.content.IntentFilter;
-    import android.os.Bundle;
-    import android.view.View;
-    import android.view.WindowManager;
-    import android.widget.TextView;
+import android.app.ActivityManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.WindowInsets;
+import android.view.WindowInsetsController;
+import android.view.WindowManager;
+import android.widget.TextView;
 
-    import androidx.appcompat.app.AppCompatActivity;
-    import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
-    public class IncomingCallActivity extends AppCompatActivity {
-        private Bundle extras;
-        private String action;
+import com.hrs.firebase.messaging.FCMPluginActivity;
+import com.samsung.android.knox.EnterpriseDeviceManager;
+import com.samsung.android.knox.EnterpriseKnoxManager;
+import com.samsung.android.knox.kiosk.KioskMode;
 
-        private final BroadcastReceiver callActionReceiver = new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                if (Constants.ACTION_CALL_LEFT.equals(intent.getAction()) ||
-                    Constants.ACTION_CALL_TIMEOUT.equals(intent.getAction())
-                ) {
-                    restoreSystemUi();
-                    finish();
+public class IncomingCallActivity extends AppCompatActivity {
+    private Bundle extras;
+    private String action;
+
+    private final BroadcastReceiver callActionReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (Constants.ACTION_CALL_LEFT.equals(intent.getAction()) ||
+                Constants.ACTION_CALL_TIMEOUT.equals(intent.getAction())
+            ) {
+                restoreSystemUi();
+                finish();
+            }
+        }
+    };
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        hideSystemUI();
+
+        setContentView(getResources().getIdentifier("activity_incoming_call", "layout", getPackageName()));
+        Log.d("AB", "----->> ON CREATE hiding system UI");
+
+        String callerName = getIntent().getStringExtra(Constants.EXTRA_CALLER_NAME);
+        String callTitle = getIntent().getStringExtra(Constants.EXTRA_CALL_TITLE);
+        extras = getIntent().getExtras();
+
+        int callerNameId = getResources().getIdentifier("caller_name", "id", getPackageName());
+        TextView callerNameView = findViewById(callerNameId);
+
+        int callTitleId = getResources().getIdentifier("call_title", "id", getPackageName());
+        TextView callTitleView = findViewById(callTitleId);
+
+        callerNameView.setText(callerName);
+        callTitleView.setText(callTitle);
+
+        // Wake up the device and show the activity
+        getWindow().addFlags(
+            WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+                WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
+                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+        );
+
+        int answerButtonId = getResources().getIdentifier("answer_button", "id", getPackageName());
+        findViewById(answerButtonId).setOnClickListener(v -> {
+            action = Constants.ACTION_ANSWER_CALL;
+            restoreSystemUi();
+//            new Handler(Looper.getMainLooper()).postDelayed(() -> {
+//                Intent incomingCallIntent = getIntent();
+//                Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
+//                int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
+//                Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
+//                intent.setAction(Constants.ACTION_ANSWER_CALL);
+//                intent.putExtra("data", data);
+//                intent.putExtra("notificationId", notificationId);
+//                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+//                startActivity(intent);
+//                finish();
+//                 }, 300);
+
+        });
+
+        int declineButtonId = getResources().getIdentifier("decline_button", "id", getPackageName());
+        findViewById(declineButtonId).setOnClickListener(v -> {
+            Intent intent = new Intent(this, IncomingCallService.class);
+            intent.setAction(Constants.ACTION_DECLINE_CALL);
+            intent.putExtras(extras);
+            startService(intent);
+            restoreSystemUi();
+            finish();
+        });
+
+        LocalBroadcastManager.getInstance(this).registerReceiver(
+            callActionReceiver, new IntentFilter(Constants.ACTION_CALL_LEFT));
+
+                    getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
+                @Override
+                public void onSystemUiVisibilityChange(int visibility) {
+                    Log.d("AB", "---->>> On System UI Visibility Change " + visibility);
+                    if(visibility == 0) {
+                        if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
+                            // Step 2: Give system a short delay to redraw nav/status bars
+                            new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                            Log.d("AB", "---->>> On System UI Visibility Change answer call action");
+                            //restoreSystemUi();
+                            Intent incomingCallIntent = getIntent();
+                            Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
+                            int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
+                            Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
+                            intent.setAction(Constants.ACTION_ANSWER_CALL);
+                            intent.putExtra("data", data);
+                            intent.putExtra("notificationId", notificationId);
+                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+
+                            startActivity(intent);
+
+                            // Step 2: Give system a short delay to redraw nav/status bars
+                           // new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                                // Step 3: Finish current activity
+                                finish();
+                                action = null;
+//                                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+//
+//                                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+                            }, 300);
+                           // finish(); // TODO thode delay se
+                        }
+                    }
                 }
-            }
-        };
-
-        @Override
-        protected void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            hideSystemUI();
-            setContentView(getResources().getIdentifier("activity_incoming_call", "layout", getPackageName()));
-
-            String callerName = getIntent().getStringExtra(Constants.EXTRA_CALLER_NAME);
-            String callTitle = getIntent().getStringExtra(Constants.EXTRA_CALL_TITLE);
-            extras = getIntent().getExtras();
-
-            int callerNameId = getResources().getIdentifier("caller_name", "id", getPackageName());
-            TextView callerNameView = findViewById(callerNameId);
-
-            int callTitleId = getResources().getIdentifier("call_title", "id", getPackageName());
-            TextView callTitleView = findViewById(callTitleId);
-
-            callerNameView.setText(callerName);
-            callTitleView.setText(callTitle);
-
-            // Wake up the device and show the activity
-            getWindow().addFlags(
-                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
-                            WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
-                            WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-            );
-
-            int answerButtonId = getResources().getIdentifier("answer_button", "id", getPackageName());
-            findViewById(answerButtonId).setOnClickListener(v -> {
-                action = Constants.ACTION_ANSWER_CALL;
-                restoreSystemUi();
-                finish();
             });
 
-            int declineButtonId = getResources().getIdentifier("decline_button", "id", getPackageName());
-            findViewById(declineButtonId).setOnClickListener(v -> {
-                Intent intent = new Intent(this, IncomingCallService.class);
-                intent.setAction(Constants.ACTION_DECLINE_CALL);
-                intent.putExtras(extras);
-                startService(intent);
-                restoreSystemUi();
-                finish();
-            });
-
-            LocalBroadcastManager.getInstance(this).registerReceiver(
-                callActionReceiver, new IntentFilter(Constants.ACTION_CALL_LEFT));
-        }
-
-
-        @Override
-        protected void onDestroy() {
-            super.onDestroy();
-            LocalBroadcastManager.getInstance(this).unregisterReceiver(callActionReceiver);
-            if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
-                Intent intent = new Intent(this, IncomingCallService.class);
-                intent.setAction(Constants.ACTION_ANSWER_CALL);
-                intent.putExtras(extras);
-                startService(intent);
-            }
-        }
-
-        private void hideSystemUI() {
-            getWindow().getDecorView().setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_IMMERSIVE
-                    | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_FULLSCREEN
-            );
-        }
-
-        private void restoreSystemUi() {
-            View decorView = getWindow().getDecorView();
-            decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        }
     }
 
+
+
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(callActionReceiver);
+    }
+
+    private void hideSystemUI() {
+        getWindow().getDecorView().setSystemUiVisibility(
+            View.SYSTEM_UI_FLAG_IMMERSIVE
+                | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                | View.SYSTEM_UI_FLAG_FULLSCREEN
+        );
+    }
+
+    private void restoreSystemUi() {
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        getWindow().getDecorView().postInvalidate();
+        // getWindow().getDecorView().requestLayout();
+    }
+}
+
+
+//    package com.hrs.firebase.messaging.incomingcall;
+//
+//    import android.app.ActivityManager;
+//    import android.app.PendingIntent;
+//    import android.content.BroadcastReceiver;
+//    import android.content.Context;
+//    import android.content.Intent;
+//    import android.content.IntentFilter;
+//    import android.os.Build;
+//    import android.os.Bundle;
+//    import android.os.Handler;
+//    import android.os.Looper;
+//    import android.util.Log;
+//    import android.view.KeyEvent;
+//    import android.view.View;
+//    import android.view.WindowInsets;
+//    import android.view.WindowInsetsController;
+//    import android.view.WindowManager;
+//    import android.widget.TextView;
+//
+//    import androidx.appcompat.app.AppCompatActivity;
+//    import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+//
+//    import com.hrs.firebase.messaging.FCMPluginActivity;
+//    import com.samsung.android.knox.EnterpriseDeviceManager;
+//    import com.samsung.android.knox.EnterpriseKnoxManager;
+//    import com.samsung.android.knox.kiosk.KioskMode;
+//
+//    public class IncomingCallActivity extends AppCompatActivity {
+//        private Bundle extras;
+//        private Intent intent;
+//        private String action;
+//
+//        private final BroadcastReceiver callActionReceiver = new BroadcastReceiver() {
+//            @Override
+//            public void onReceive(Context context, Intent intent) {
+//                if (Constants.ACTION_CALL_LEFT.equals(intent.getAction()) ||
+//                    Constants.ACTION_CALL_TIMEOUT.equals(intent.getAction())
+//                ) {
+//                    restoreSystemUi();
+//                    finish();
+//                }
+//            }
+//        };
+//
+//
+//        @Override
+//        protected void onCreate(Bundle savedInstanceState) {
+//            super.onCreate(savedInstanceState);
+//            hideSystemUI();
+////            EnterpriseDeviceManager ekm = EnterpriseDeviceManager.getInstance(this);
+////            KioskMode kiosk = ekm.getKioskMode();
+////            // kiosk.allowTaskManager(false);
+////            kiosk.hideNavigationBar(true);
+////            kiosk.hideStatusBar(true);
+////            // startLockTask();
+//
+//            setContentView(getResources().getIdentifier("activity_incoming_call", "layout", getPackageName()));
+//            Log.d("AB", "----->> ON CREATE hiding system UI");
+//
+//            String callerName = getIntent().getStringExtra(Constants.EXTRA_CALLER_NAME);
+//            String callTitle = getIntent().getStringExtra(Constants.EXTRA_CALL_TITLE);
+//            // intent = getIntent();
+//            extras = getIntent().getExtras();
+//
+//            int callerNameId = getResources().getIdentifier("caller_name", "id", getPackageName());
+//            TextView callerNameView = findViewById(callerNameId);
+//
+//            int callTitleId = getResources().getIdentifier("call_title", "id", getPackageName());
+//            TextView callTitleView = findViewById(callTitleId);
+//
+//            callerNameView.setText(callerName);
+//            callTitleView.setText(callTitle);
+//
+//            // Wake up the device and show the activity
+//            getWindow().addFlags(
+//                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+//                            WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
+//                            WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+//            );
+//
+//            getWindow().setFlags(
+//                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+//                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+//            );
+//
+//            int answerButtonId = getResources().getIdentifier("answer_button", "id", getPackageName());
+//            findViewById(answerButtonId).setOnClickListener(v -> {
+//                  action = Constants.ACTION_ANSWER_CALL;
+//                  restoreSystemUi();
+//
+////                // Step 2: Give system a short delay to redraw nav/status bars
+////                new Handler(Looper.getMainLooper()).postDelayed(() -> {
+////                    // Step 3: Finish current activity
+////                    finish();
+////
+////                    // Step 4: Launch next activity
+////                    Intent incomingCallIntent = getIntent();
+////                Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
+////                int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
+////                Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
+////                intent.setAction(Constants.ACTION_ANSWER_CALL);
+////                intent.putExtra("data", data);
+////                intent.putExtra("notificationId", notificationId);
+////                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+////                startActivity(intent);
+////
+////                }, 300);
+////                  finish();
+//                //restoreSystemUi();
+////                Intent incomingCallIntent = getIntent();
+////                Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
+////                int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
+////                Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
+////                intent.setAction(Constants.ACTION_ANSWER_CALL);
+////                intent.putExtra("data", data);
+////                intent.putExtra("notificationId", notificationId);
+////                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+////                // restoreSystemUi();
+////                startActivity(intent);
+////                // restoreSystemUi();
+////                finish();
+//            });
+//
+//            int declineButtonId = getResources().getIdentifier("decline_button", "id", getPackageName());
+//            findViewById(declineButtonId).setOnClickListener(v -> {
+//                Intent intent = new Intent(this, IncomingCallService.class);
+//                intent.setAction(Constants.ACTION_DECLINE_CALL);
+//                intent.putExtras(extras);
+//                startService(intent);
+//                //restoreSystemUi();
+//                finish();
+//            });
+//
+//            LocalBroadcastManager.getInstance(this).registerReceiver(
+//                callActionReceiver, new IntentFilter(Constants.ACTION_CALL_LEFT));
+//
+//
+////            /**
+////             * Still issue occurs
+////             */
+//            getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
+//                @Override
+//                public void onSystemUiVisibilityChange(int visibility) {
+//                    Log.d("AB", "---->>> On System UI Visibility Change " + visibility);
+//                    if(visibility == 0) {
+//                        if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
+//                            // Step 2: Give system a short delay to redraw nav/status bars
+//                            new Handler(Looper.getMainLooper()).postDelayed(() -> {
+//                            Log.d("AB", "---->>> On System UI Visibility Change answer call action");
+//                            //restoreSystemUi();
+//                            Intent incomingCallIntent = getIntent();
+//                            Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
+//                            int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
+//                            Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
+//                            intent.setAction(Constants.ACTION_ANSWER_CALL);
+//                            intent.putExtra("data", data);
+//                            intent.putExtra("notificationId", notificationId);
+//                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+//
+//                            startActivity(intent);
+//
+//                            // Step 2: Give system a short delay to redraw nav/status bars
+//                           // new Handler(Looper.getMainLooper()).postDelayed(() -> {
+//                                // Step 3: Finish current activity
+//                                finish();
+//                                action = null;
+////                                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+////
+////                                getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+//                            }, 300);
+//                           // finish(); // TODO thode delay se
+//                        }
+//                    }
+//                }
+//            });
+//        }
+//
+//        @Override
+//        public void onBackPressed() {
+//           // super.onBackPressed();
+//        }
+//
+//        @Override
+//        public boolean dispatchKeyEvent(KeyEvent event) {
+//            int keyCode = event.getKeyCode();
+//            if (keyCode == KeyEvent.KEYCODE_HOME || keyCode == KeyEvent.KEYCODE_APP_SWITCH) {
+//                return true; // Block home & app switch keys
+//            }
+//            return super.dispatchKeyEvent(event);
+//        }
+//
+////        @Override
+////        protected void onResume() {
+////            super.onResume();
+////            startLockTask();
+////        }
+//
+//        @Override
+//        protected void onDestroy() {
+//            super.onDestroy();
+//            LocalBroadcastManager.getInstance(this).unregisterReceiver(callActionReceiver);
+////            if (action != null && action.equals(Constants.ACTION_ANSWER_CALL)) {
+//////                Intent intent = new Intent(this, IncomingCallService.class);
+//////                intent.setAction(Constants.ACTION_ANSWER_CALL);
+//////                intent.putExtras(extras);
+//////                startService(intent);
+////                Intent incomingCallIntent = getIntent();
+////                Bundle data = incomingCallIntent.getBundleExtra(Constants.EXTRA_CALL_DATA);
+////                int notificationId = incomingCallIntent.getIntExtra("notificationId", -1);
+////                Intent intent = new Intent(IncomingCallActivity.this, FCMPluginActivity.class);
+////                intent.setAction(Constants.ACTION_ANSWER_CALL);
+////                intent.putExtra("data", data);
+////                intent.putExtra("notificationId", notificationId);
+////                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+////                startActivity(intent);
+////            }
+//        }
+//
+//
+////        @Override
+////        protected void onStop() {
+////            super.onStop();
+////            Log.d("AB", "----->> ON STOP restoring system UI");
+////            restoreSystemUi();
+////        }
+//
+//        private void hideSystemUI() {
+//
+//            getWindow().getDecorView().setSystemUiVisibility(
+//                View.SYSTEM_UI_FLAG_IMMERSIVE
+//                    | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+//                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+//                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+//                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+//                    | View.SYSTEM_UI_FLAG_FULLSCREEN
+//            );
+////            getWindow().getDecorView().setSystemUiVisibility(
+////                     View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+////                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+////                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+////                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+////                    | View.SYSTEM_UI_FLAG_FULLSCREEN
+////            );
+//        }
+////
+//        private void restoreSystemUi() {
+//
+////            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+////                WindowInsetsController controller = getWindow().getInsetsController();
+////                if (controller != null) {
+////                    controller.show(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
+////                    controller.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_DEFAULT);
+////                }
+////            } else {
+//
+//            //NEHAL
+//            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+////            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+////            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+//            //}
+//            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+//            getWindow().getDecorView().postInvalidate();
+//            //getWindow().getDecorView().invalidate();
+//            getWindow().getDecorView().requestLayout();;
+//
+//
+////            View decorView = getWindow().getDecorView();
+////            decorView.setSystemUiVisibility(
+////                View.SYSTEM_UI_FLAG_VISIBLE | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+////            );
+////            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+//            //getWindow().addFlags(
+//            //                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+//            //                            WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
+//            //                            WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+//            //            );
+////            View decorView = getWindow().getDecorView();
+////            decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+////            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+////            getWindow().clearFlags(
+////                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+////                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
+////                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+////            );
+//
+//        }
+//    }
+//

--- a/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
+++ b/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
@@ -1,20 +1,11 @@
 package com.hrs.firebase.messaging.incomingcall;
 
-import android.app.ActivityManager;
-import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
-import android.util.Log;
-import android.view.KeyEvent;
 import android.view.View;
-import android.view.WindowInsets;
-import android.view.WindowInsetsController;
 import android.view.WindowManager;
 import android.widget.TextView;
 
@@ -22,9 +13,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.hrs.firebase.messaging.FCMPluginActivity;
-import com.samsung.android.knox.EnterpriseDeviceManager;
-import com.samsung.android.knox.EnterpriseKnoxManager;
-import com.samsung.android.knox.kiosk.KioskMode;
 
 public class IncomingCallActivity extends AppCompatActivity {
     private Bundle extras;

--- a/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
+++ b/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallActivity.java
@@ -30,12 +30,10 @@
             }
         };
 
-
         @Override
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             hideSystemUI();
-
             setContentView(getResources().getIdentifier("activity_incoming_call", "layout", getPackageName()));
 
             String callerName = getIntent().getStringExtra(Constants.EXTRA_CALLER_NAME);
@@ -53,9 +51,9 @@
 
             // Wake up the device and show the activity
             getWindow().addFlags(
-                WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
-                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
-                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+                        WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON |
+                        WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
             );
 
             int answerButtonId = getResources().getIdentifier("answer_button", "id", getPackageName());
@@ -110,7 +108,8 @@
         }
 
         private void restoreSystemUi() {
-            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
-            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            View decorView = getWindow().getDecorView();
+            decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         }
     }

--- a/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallService.java
+++ b/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallService.java
@@ -20,6 +20,8 @@ import android.os.Looper;
 import androidx.core.app.NotificationCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
+import com.hrs.firebase.messaging.FCMPluginActivity;
+
 import java.util.Objects;
 
 public class IncomingCallService extends Service {
@@ -44,6 +46,8 @@ public class IncomingCallService extends Service {
         if (timeoutRunnable != null) {
             timeoutHandler.removeCallbacks(timeoutRunnable);
         }
+
+        stopForeground(true);  // remove the notification
     }
 
     @Override
@@ -83,7 +87,7 @@ public class IncomingCallService extends Service {
     private void showIncomingCallNotification(Intent intent) {
         Bundle extras = intent.getExtras();
         PendingIntent fullScreenIntent = getFullScreenIntent(extras);
-        PendingIntent answerIntent = getAnswerIntent(extras);
+        PendingIntent answerIntent = getAnswerIntent(extras, intent);
         PendingIntent declineIntent = getDeclineIntent(extras);
 
 
@@ -160,12 +164,30 @@ public class IncomingCallService extends Service {
         );
     }
 
-    private PendingIntent getAnswerIntent(Bundle extras) {
-        Intent answerIntent = new Intent(this, IncomingCallService.class);
-        answerIntent.setAction(Constants.ACTION_ANSWER_CALL);
-        answerIntent.putExtras(extras);
+    private PendingIntent getAnswerIntent(Bundle extras, Intent intent) {
+//        Intent answerIntent = new Intent(this, IncomingCallService.class);
+//        answerIntent.setAction(Constants.ACTION_ANSWER_CALL);
+//        answerIntent.putExtras(extras);
+//
+//        return PendingIntent.getService(
+//            this,
+//            0,
+//            answerIntent,
+//            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+//        );
 
-        return PendingIntent.getService(
+//        Intent answerIntent = new Intent(context, FCMPluginActivity.class);
+//        answerIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+//        Bundle data = intent.getBundleExtra(Constants.EXTRA_CALL_DATA);
+//        answerIntent.putExtra("data", data);
+
+       // context.startActivity(answerIntent);
+        Intent answerIntent = new Intent(this, FCMPluginActivity.class);
+        answerIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        answerIntent.setAction(Constants.ACTION_ANSWER_CALL);
+        Bundle data = intent.getBundleExtra(Constants.EXTRA_CALL_DATA);
+        answerIntent.putExtra("data", data);
+        return PendingIntent.getActivity(
             this,
             0,
             answerIntent,

--- a/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallService.java
+++ b/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallService.java
@@ -87,7 +87,7 @@ public class IncomingCallService extends Service {
     private void showIncomingCallNotification(Intent intent) {
         Bundle extras = intent.getExtras();
         PendingIntent fullScreenIntent = getFullScreenIntent(extras);
-        PendingIntent answerIntent = getAnswerIntent(extras, intent);
+        PendingIntent answerIntent = getAnswerIntent(intent);
         PendingIntent declineIntent = getDeclineIntent(extras);
 
 
@@ -164,24 +164,7 @@ public class IncomingCallService extends Service {
         );
     }
 
-    private PendingIntent getAnswerIntent(Bundle extras, Intent intent) {
-//        Intent answerIntent = new Intent(this, IncomingCallService.class);
-//        answerIntent.setAction(Constants.ACTION_ANSWER_CALL);
-//        answerIntent.putExtras(extras);
-//
-//        return PendingIntent.getService(
-//            this,
-//            0,
-//            answerIntent,
-//            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
-//        );
-
-//        Intent answerIntent = new Intent(context, FCMPluginActivity.class);
-//        answerIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-//        Bundle data = intent.getBundleExtra(Constants.EXTRA_CALL_DATA);
-//        answerIntent.putExtra("data", data);
-
-       // context.startActivity(answerIntent);
+    private PendingIntent getAnswerIntent(Intent intent) {
         Intent answerIntent = new Intent(this, FCMPluginActivity.class);
         answerIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         answerIntent.setAction(Constants.ACTION_ANSWER_CALL);

--- a/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallService.java
+++ b/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallService.java
@@ -166,7 +166,7 @@ public class IncomingCallService extends Service {
 
     private PendingIntent getAnswerIntent(Intent intent) {
         Intent answerIntent = new Intent(this, FCMPluginActivity.class);
-        answerIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        answerIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         answerIntent.setAction(Constants.ACTION_ANSWER_CALL);
         Bundle data = intent.getBundleExtra(Constants.EXTRA_CALL_DATA);
         answerIntent.putExtra("data", data);


### PR DESCRIPTION
This issue happened as in the closed state, IncomingCallService was showing the notification and on clicking answerIntent it was again asking IncomingCallService to handle that use case. For the app in bg and open this worked fine due to LocalBroadcastManager handling this but for app closed state that didn't work. Added implementation to handle all the use cases. 
Dev tested application with :
- App closed, sleep : Incoming voice/video call, answer decline button work fine. App launches and call connects properly when accepted
- App in bg / fg / bg sleep : Incoming voice/video call, answer decline button work fine. App launches and call connects properly when accepted