### PR TITLE
DEV-20282 [KM PCMT] A ringing sound is heard when a Voice/Video call is initiated to PCMT, even if the volume is set to zero and the app is in the background or closed

### DIFF
--- a/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallService.java
+++ b/src/android/com/hrs/firebase/messaging/incomingcall/IncomingCallService.java
@@ -138,9 +138,9 @@ public class IncomingCallService extends Service {
             );
 
             AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
-                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                    .build();
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                .build();
 
             channel.setSound(ringtoneUri, audioAttributes);
             channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC);


### PR DESCRIPTION
Currently, we were using the Ringtone audio stream for notification banner sounds. Without Do Not Disturb (DND) permission, Android would not allow the stream volume to go fully to zero, so a faint ringing could still be heard. The earlier codebase (3.7.4) used the default Media channel for this. We have now updated the current codebase to use the Media stream for notifications, allowing users to adjust the volume down to zero properly.

With this fix, 2 issues have been addressed DEV-20282(https://healthrecoverysolutions.atlassian.net/browse/DEV-20282), and DEV-21297 (https://healthrecoverysolutions.atlassian.net/browse/DEV-21297). This change has been dev tested and buddy tested for both issues and all use cases work fine (app bg, fg, closed, sleep)