### PR TITLE
DEV-22897: Add data-only FCM push notification support for iOS

### DIFF
--- a/src/ios/AppDelegate+FCMPlugin.h
+++ b/src/ios/AppDelegate+FCMPlugin.h
@@ -13,5 +13,8 @@
 + (void)setInitialPushPayload:(NSDictionary*)payload;
 + (void)requestPushPermission:(void (^)(BOOL yesOrNo, NSError* error))block withOptions:(NSDictionary*)options;
 + (void)hasPushPermission:(void (^)(NSNumber* yesNoOrNil))block;
++ (void)scheduleLocalNotificationForDataPush:(NSDictionary *)userInfo withParsedData:(NSDictionary *)parsedData;
++ (void)storeDataNotification:(NSDictionary *)notification;
++ (NSArray *)getDeliveredNotifications;
 
 @end

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -125,9 +125,12 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
         // Print full message.
         DDLogDebug(@"%@", userInfo);
 
-        // Detect data-only push: presence of our jsonData key with no display notification.
+        // Detect data-only push: our jsonData key is present AND there is no aps.alert,
+        // since a standard display notification can also carry a data payload with jsonData.
         NSString *jsonDataString = userInfo[@"jsonData"];
-        BOOL isDataOnlyPush = (jsonDataString != nil && [jsonDataString isKindOfClass:[NSString class]]);
+        NSDictionary *aps = userInfo[@"aps"];
+        BOOL hasDisplayNotification = (aps[@"alert"] != nil);
+        BOOL isDataOnlyPush = !hasDisplayNotification && (jsonDataString != nil && [jsonDataString isKindOfClass:[NSString class]]);
 
         if (isDataOnlyPush) {
             DDLogDebug(@"Data-only push received with jsonData key");

--- a/src/ios/AppDelegate+FCMPlugin.m
+++ b/src/ios/AppDelegate+FCMPlugin.m
@@ -24,6 +24,7 @@ static NSDictionary *initialPushPayload;
 static NSString *fcmToken;
 static NSString *apnsToken;
 NSString *const kGCMMessageIDKey = @"gcm.message_id";
+NSString *const kHRSPendingDataNotificationsKey = @"HRSPendingDataNotifications";
 FCMNotificationCenterDelegate *notificationCenterDelegate;
 
 //Method swizzling
@@ -121,8 +122,43 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
         // Print message ID.
         DDLogDebug(@"Message ID: %@", userInfo[@"gcm.message_id"]);
 
-        // Pring full message.
+        // Print full message.
         DDLogDebug(@"%@", userInfo);
+
+        // Detect data-only push: presence of our jsonData key with no display notification.
+        NSString *jsonDataString = userInfo[@"jsonData"];
+        BOOL isDataOnlyPush = (jsonDataString != nil && [jsonDataString isKindOfClass:[NSString class]]);
+
+        if (isDataOnlyPush) {
+            DDLogDebug(@"Data-only push received with jsonData key");
+            NSError *parseError;
+            NSData *jsonBytes = [jsonDataString dataUsingEncoding:NSUTF8StringEncoding];
+            NSDictionary *parsedData = [NSJSONSerialization JSONObjectWithData:jsonBytes options:0 error:&parseError];
+
+            if (application.applicationState == UIApplicationStateBackground ||
+                application.applicationState == UIApplicationStateInactive) {
+                // Persist notification so the app can process it after launch.
+                NSMutableDictionary *storedPayload = [userInfo mutableCopy];
+                [storedPayload setValue:@(NO) forKey:@"wasTapped"];
+                [AppDelegate storeDataNotification:storedPayload];
+                lastPush = storedPayload;
+
+                // Show a visible notification in the system tray.
+                if (!parseError && parsedData) {
+                    [AppDelegate scheduleLocalNotificationForDataPush:userInfo withParsedData:parsedData];
+                } else {
+                    DDLogDebug(@"Failed to parse jsonData for local notification: %@", parseError);
+                }
+                completionHandler(UIBackgroundFetchResultNewData);
+            } else if (application.applicationState == UIApplicationStateActive) {
+                // App is in foreground — dispatch directly to JS.
+                NSMutableDictionary *pushData = [userInfo mutableCopy];
+                DDLogDebug(@"Data-only push received while app active, dispatching to JS");
+                [FCMPlugin dispatchNotification:pushData];
+                completionHandler(UIBackgroundFetchResultNewData);
+            }
+            return;
+        }
 
         // If the app is in the background, keep it for later, in case it's not tapped.
         if(application.applicationState == UIApplicationStateBackground) {
@@ -250,6 +286,52 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
         [hexString appendFormat:@"%02x", dataBuffer[i]];
     }
     return [hexString copy];
+}
+
+// Schedule a visible local notification in the system tray for a data-only FCM push.
++ (void)scheduleLocalNotificationForDataPush:(NSDictionary *)userInfo withParsedData:(NSDictionary *)parsedData {
+    NSString *title = parsedData[@"title"] ?: @"Notification";
+    NSString *body = parsedData[@"body"] ?: @"";
+    // Use the payload id as the notification identifier so duplicates are deduplicated by the OS.
+    NSString *notificationId = parsedData[@"id"] ?: [[NSUUID UUID] UUIDString];
+
+    UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+    content.title = title;
+    content.body = body;
+    content.sound = [UNNotificationSound defaultSound];
+    // Embed the original FCM userInfo so it can be recovered when the notification is tapped.
+    content.userInfo = userInfo;
+
+    UNTimeIntervalNotificationTrigger *trigger = [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:1 repeats:NO];
+    UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:notificationId content:content trigger:trigger];
+    [[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:^(NSError *error) {
+        if (error) {
+            DDLogDebug(@"Data notification scheduling error: %@", error);
+        } else {
+            DDLogDebug(@"Data notification scheduled with id: %@", notificationId);
+        }
+    }];
+}
+
+// Persist a data-only notification to NSUserDefaults so it survives app termination.
++ (void)storeDataNotification:(NSDictionary *)notification {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSArray *existing = [defaults arrayForKey:kHRSPendingDataNotificationsKey];
+    NSMutableArray *updated = existing ? [existing mutableCopy] : [NSMutableArray array];
+    [updated addObject:notification];
+    [defaults setObject:[updated copy] forKey:kHRSPendingDataNotificationsKey];
+    [defaults synchronize];
+    DDLogDebug(@"Stored data notification. Total pending: %lu", (unsigned long)updated.count);
+}
+
+// Retrieve and clear all persistently stored data-only notifications.
++ (NSArray *)getDeliveredNotifications {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSArray *notifications = [defaults arrayForKey:kHRSPendingDataNotificationsKey];
+    [defaults removeObjectForKey:kHRSPendingDataNotificationsKey];
+    [defaults synchronize];
+    DDLogDebug(@"Retrieved %lu pending data notifications", (unsigned long)notifications.count);
+    return notifications ?: @[];
 }
 
 // Added deleteInstanceId method in AppDelegate+FCMPlugin.m as it is being consumed in logout.

--- a/src/ios/FCMNotificationCenterDelegate.m
+++ b/src/ios/FCMNotificationCenterDelegate.m
@@ -61,10 +61,23 @@ NSMutableArray<NSObject<UNUserNotificationCenterDelegate>*> *subNotificationCent
        willPresentNotification:(UNNotification *)notification
          withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
     DDLogDebug(@"FCMNotificationCenterDelegate.willPresentNotification!");
+
+    // If this is our locally-scheduled data-only notification, present it visually.
+    // Do not dispatch to JS here — the payload will be delivered when the user taps it.
+    NSDictionary *notificationUserInfo = notification.request.content.userInfo;
+    if (notificationUserInfo[@"jsonData"] != nil) {
+        DDLogDebug(@"Data-only local notification will present visually");
+        if (@available(iOS 14.0, *)) {
+            completionHandler(UNNotificationPresentationOptionList | UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionSound);
+        } else {
+            completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionSound);
+        }
+        return;
+    }
+
     NSDictionary *jsonData = [self extractJSONData:notification withWasTapped:NO];
     [FCMPlugin dispatchNotification:jsonData];
-    __block UNNotificationPresentationOptions notificationPresentationOptions = UNNotificationPresentationOptionNone;
-    completionHandler(notificationPresentationOptions);
+    completionHandler(UNNotificationPresentationOptionNone);
 }
 
 // Handle notification messages after display notification is tapped by the user.

--- a/src/ios/FCMPlugin.h
+++ b/src/ios/FCMPlugin.h
@@ -13,6 +13,7 @@
 - (void)returnTokenOrRetry:(void (^)(NSString* fcmToken))onSuccess;
 - (void)getAPNSToken:(CDVInvokedUrlCommand*)command;
 - (void)getInitialPushPayload:(CDVInvokedUrlCommand*)command;
+- (void)getDeliveredNotifications:(CDVInvokedUrlCommand*)command;
 - (void)deleteInstanceId:(CDVInvokedUrlCommand*)command;
 - (void)clearAllNotifications:(CDVInvokedUrlCommand *)command;
 - (void)subscribeToTopic:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FCMPlugin.m
+++ b/src/ios/FCMPlugin.m
@@ -200,6 +200,16 @@ static FCMPlugin *fcmPluginInstance = nil;
     }];
 }
 
+- (void)getDeliveredNotifications:(CDVInvokedUrlCommand *)command {
+    DDLogDebug(@"getDeliveredNotifications");
+    [self.commandDelegate runInBackground:^{
+        NSArray *notifications = [AppDelegate getDeliveredNotifications];
+        DDLogDebug(@"getDeliveredNotifications returning %lu items", (unsigned long)notifications.count);
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:notifications];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
+}
+
 - (void)deleteInstanceId:(CDVInvokedUrlCommand *)command {
     [self.commandDelegate runInBackground:^{
         [AppDelegate deleteInstanceId:^(NSError *error) {

--- a/src/ts/cordova-plugin-fcm-with-dependecy-updated.ts
+++ b/src/ts/cordova-plugin-fcm-with-dependecy-updated.ts
@@ -280,7 +280,7 @@ export class FirebaseMessagingCordovaInterface {
         return invoke('initDifferentAccount', accountInfo);
     }
 
-    public getDeliveredNotifications(): Promise<any> {
+    public getDeliveredNotifications(): Promise<INotificationPayload[]> {
         return invoke('getDeliveredNotifications');
     }
 }


### PR DESCRIPTION
Handles FCM messages that carry a `jsonData` payload key but no display notification, enabling silent background delivery with user-visible alerts.

Changes:
- AppDelegate+FCMPlugin.m: Detect data-only pushes (presence of `jsonData` key) in `didReceiveRemoteNotification:fetchCompletionHandler:`. When received in the background/inactive state, parse `jsonData` to schedule a local UNUserNotificationRequest (title/body/sound) with the original FCM userInfo embedded for tap recovery, persist the payload to NSUserDefaults so it survives app termination, and call completionHandler with NewData. Active (foreground) pushes are dispatched directly to the JS bridge as before.
- AppDelegate+FCMPlugin.m: Add `scheduleLocalNotificationForDataPush:withParsedData:` to build and post a UNNotificationRequest; uses `jsonData.id` as the notification identifier to deduplicate retries at the OS level.
- AppDelegate+FCMPlugin.m: Add `storeDataNotification:` / `getDeliveredNotifications` to persist and retrieve the notification array from NSUserDefaults, clearing the store on retrieval.
- FCMNotificationCenterDelegate.m: In `willPresentNotification:`, detect locally-scheduled data notifications by the presence of `jsonData` in userInfo and present them visually (banner + sound) instead of suppressing them; regular FCM notifications continue to be dispatched silently to JS.
- FCMPlugin.m/h: Expose `getDeliveredNotifications` as a Cordova bridge method returning the stored notification array to JavaScript.
- JS/TS: `getDeliveredNotifications()` now returns `Promise<INotificationPayload[]>` and calls the unified `getDeliveredNotifications` native method on all platforms.