### PR TITLE
Fixed DEV-24710 DEV-24710 [PCM] iOS/Android - Rest Banner Displayed Instead of Retry Banner After Retry Notification Is Received

### DIFF
--- a/lib/cordova-plugin-fcm-with-dependecy-updated.d.ts
+++ b/lib/cordova-plugin-fcm-with-dependecy-updated.d.ts
@@ -167,6 +167,7 @@ export declare class FirebaseMessagingCordovaInterface {
     unsubscribeFromTopic(topic: string): Promise<void>;
     initDifferentAccount(accountInfo: any): Promise<void>;
     getDeliveredNotifications(): Promise<any>;
+    peekDeliveredNotifications(): Promise<any>;
 }
 export declare const FirebaseMessaging: FirebaseMessagingCordovaInterface;
 export {};

--- a/lib/cordova-plugin-fcm-with-dependecy-updated.js
+++ b/lib/cordova-plugin-fcm-with-dependecy-updated.js
@@ -172,5 +172,8 @@ export class FirebaseMessagingCordovaInterface {
     getDeliveredNotifications() {
         return invoke('getDeliveredNotifications');
     }
+    peekDeliveredNotifications() {
+        return invoke('peekDeliveredNotifications');
+    }
 }
 export const FirebaseMessaging = new FirebaseMessagingCordovaInterface();

--- a/src/android/com/hrs/firebase/messaging/FCMPlugin.java
+++ b/src/android/com/hrs/firebase/messaging/FCMPlugin.java
@@ -45,6 +45,7 @@ public class FCMPlugin extends CordovaPlugin {
     private static final String ACTION_DELETE_INSTANCE_ID = "deleteInstanceId";
     private static final String ACTION_HAS_PERMISSION = "hasPermission";
     private static final String ACTION_GET_DELIVERED_NOTIFICATIONS = "getDeliveredNotifications";
+    private static final String ACTION_PEEK_DELIVERED_NOTIFICATIONS = "peekDeliveredNotifications";
 
     private static final String EVENT_TYPE_NOTIFICATION = "notification";
     private static final String EVENT_TYPE_TOKEN_REFRESH = "tokenRefresh";
@@ -192,6 +193,10 @@ public class FCMPlugin extends CordovaPlugin {
                     break;
                 case ACTION_GET_DELIVERED_NOTIFICATIONS:
                     getDeliveredNotifications(callbackContext);
+                    break;
+                case ACTION_PEEK_DELIVERED_NOTIFICATIONS:
+                    peekDeliveredNotifications(callbackContext);
+                    break;
                 case ACTION_CLEAR_ALL_NOTIFICATIONS:
                     cordova.getThreadPool().execute(() -> {
                         try {
@@ -237,12 +242,31 @@ public class FCMPlugin extends CordovaPlugin {
         callbackContext.success();
     }
 
+     /**
+     *  Returns all currently stored/delivered Firebase notifications
+     *  and removes them from SharedPreferences storage.
+     */
     private void getDeliveredNotifications(CallbackContext callbackContext) {
         JSONObject result = null;
         try {
             SharedPreferencesManager sharedPreferencesManager = SharedPreferencesManager.getInstance(cordova.getContext());
             result = sharedPreferencesManager.getNotifications();
             sharedPreferencesManager.clearNotifications();
+            callbackContext.success(result);
+        } catch (JSONException e) {
+            callbackContext.error("Error fetching notifications: " + e.getMessage());
+        }
+    }
+
+    /**
+     *  Returns all currently stored/delivered Firebase notifications
+     *  without removing them from SharedPreferences storage.
+     */
+    private void peekDeliveredNotifications(CallbackContext callbackContext) {
+        JSONObject result = null;
+        try {
+            SharedPreferencesManager sharedPreferencesManager = SharedPreferencesManager.getInstance(cordova.getContext());
+            result = sharedPreferencesManager.getNotifications();
             callbackContext.success(result);
         } catch (JSONException e) {
             callbackContext.error("Error fetching notifications: " + e.getMessage());

--- a/src/ts/cordova-plugin-fcm-with-dependecy-updated.ts
+++ b/src/ts/cordova-plugin-fcm-with-dependecy-updated.ts
@@ -283,6 +283,10 @@ export class FirebaseMessagingCordovaInterface {
     public getDeliveredNotifications(): Promise<any> {
         return invoke('getDeliveredNotifications');
     }
+
+    public getDeliveredNotificationsWithoutClearing(): Promise<any> {
+        return invoke('getDeliveredNotificationsWithoutClearing');
+    }
 }
 
 export const FirebaseMessaging = new FirebaseMessagingCordovaInterface();

--- a/www/cordova-plugin-fcm-with-dependecy-updated.js
+++ b/www/cordova-plugin-fcm-with-dependecy-updated.js
@@ -182,6 +182,9 @@ var FirebaseMessagingCordovaInterface = /** @class */ (function () {
     FirebaseMessagingCordovaInterface.prototype.getDeliveredNotifications = function () {
         return invoke('getDeliveredNotifications');
     };
+    FirebaseMessagingCordovaInterface.prototype.getDeliveredNotificationsWithoutClearing = function () {
+        return invoke('getDeliveredNotificationsWithoutClearing');
+    };
     return FirebaseMessagingCordovaInterface;
 }());
 exports.FirebaseMessagingCordovaInterface = FirebaseMessagingCordovaInterface;


### PR DESCRIPTION
Added one method which provides all the delivered notifications from the tray (which are storing). Earlier similar method was deleting the notifications as well thus this wasn't useful in case where we just wanted to peek/read the notifications. 